### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/optimusprimeodiseo01-debug/Valores-/security/code-scanning/1](https://github.com/optimusprimeodiseo01-debug/Valores-/security/code-scanning/1)

To fix the problem, we should explicitly define restricted `GITHUB_TOKEN` permissions for this workflow, following the principle of least privilege. Since the workflow only checks out the repository and runs tests/echo commands, it only needs read access to the repository contents. The simplest and safest fix is to add a `permissions:` block at the workflow root level (just under the `name:` or `on:` section) setting `contents: read`. This will apply to all jobs in the workflow that don’t override `permissions`, including the `build` job.

Concretely, in `.github/workflows/main.yml`, add:

```yaml
permissions:
  contents: read
```

near the top of the file, so that the entire workflow uses a read-only token for repository contents. We do not need any imports or additional methods; this is purely a YAML configuration change within the workflow file, and it does not alter existing functionality of the job steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
